### PR TITLE
made API return prebound middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 redux-simple-localstorage
 =============
 
-Ridiculously simple implementation for serialising the entire Redux store to local storage and retreiving it on application restart.
+Ridiculously simple implementation for serialising the entire Redux store to local storage and retrieving it on application restart.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ import { saveLocal, savedState } from "redux-simple-localstorage";
 import rootReducer from "./reducers/index";
 import initialState from "./initialstate";
 
-// create a store that has saveLocal middleware with the key as a bound parameter
-const store = applyMiddleware(saveLocal.bind(null, "Key"))(createStore)(rootReducer, savedState("Key") || initialState());
+// create a store that will continuously save its state to localStorage at `"Key"`
+// and use eventual previously stored state at app start
+const store = applyMiddleware(saveLocal("Key"))(createStore)(rootReducer, savedState("Key") || initialState);
 ```
 
 ## License

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,6 @@ export const saveLocal = key => store => next => action => {
   	return result;
 };
 
-export const getSavedState = key => {
+export const savedState = key => {
 	return JSON.parse(window.localStorage.getItem(key));
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,11 @@
 "use strict";
 
-export const saveLocal = (key, store) => next => action => {
+export const saveLocal = key => store => next => action => {
 	let result = next(action);
 	window.localStorage.setItem(key, JSON.stringify(store.getState()));
   	return result;
 };
 
-export const savedState = (key) => {
+export const getSavedState = key => {
 	return JSON.parse(window.localStorage.getItem(key));
 };


### PR DESCRIPTION
I changed the API so that instead of having to bind a method with the signature `(key, store)`, the method now just has the signature `(key)` but returns a method with signature `(store)` which returns the same as the old one. Also tweaked the README accordingly.
