### PR TITLE
new api again

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,25 @@ Ridiculously simple implementation for serialising the entire Redux store to loc
 npm install --save redux-simple-localstorage
 ```
 
-To enable, use [`applyMiddleware()`](http://rackt.github.io/redux/docs/api/applyMiddleware.html) and pass the `savedState` to the reducers:
+## Usage
+
+The module exports a single function. Call that with the localStorage key, and you get an object with a `read` and `write` method:
+
+```js
+import ReduxLocalstorage from "redux-simple-localstorage"
+const {read,write} = ReduxLocalstorage("myKey");
+```
+
+Now use `write` as a middleware and the result of `read` as initial state when you define your store:
 
 ```js
 import { createStore, applyMiddleware } from "redux";
 import { saveLocal, savedState } from "redux-simple-localstorage";
+
 import rootReducer from "./reducers/index";
 import initialState from "./initialstate";
 
-// create a store that will continuously save its state to localStorage at `"Key"`
-// and use eventual previously stored state at app start
-const store = applyMiddleware(saveLocal("Key"))(createStore)(rootReducer, savedState("Key") || initialState);
+const store = applyMiddleware(write)(createStore)(rootReducer, read() || initialState);
 ```
 
 ## License

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,10 @@
 "use strict";
 
-export const saveLocal = key => store => next => action => {
-	let result = next(action);
-	window.localStorage.setItem(key, JSON.stringify(store.getState()));
-  	return result;
-};
-
-export const savedState = key => {
-	return JSON.parse(window.localStorage.getItem(key));
-};
+export default key => ({
+	write: store => next => action => {
+		let result = next(action);
+		window.localStorage.setItem(key, JSON.stringify(store.getState()));
+		return result;
+	},
+	read: ()=> JSON.parse(window.localStorage.getItem(key))
+})


### PR DESCRIPTION
I didn't really like how I had to feed the `key` to both the read and write method. Why would I ever want different ones? So I did another refactor, where the module exports a single function which takes the key and returns the methods with no need for any parameters.

Not entirely sure this refactoring is a good idea though - I would definitely prefer it personally, but perhaps others (you?) would be put off by the double step need. What do you think?
